### PR TITLE
docs: polish README.md to align with upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,29 @@
 # Linux 内核揭秘
 
-一系列关于 Linux 内核和其内在机理的帖子。
+本仓库包含一本关于 Linux 内核及其内在机理的在编书籍，是 [linux-insides](https://github.com/0xAX/linux-insides) 的中文翻译版本。
 
-**目的很简单** - 分享我对 Linux 内核机理的一些浅见，帮助读者理解 Linux 内核机理和其他底层内容。从 [这里](https://github.com/hust-open-atom-club/linux-insides-zh/blob/master/SUMMARY.md) 开始阅读这本书吧。
+**目的很简单** - 分享 Linux 内核内部原理及相关底层主题的知识。如果你想了解 Linux 内核的底层运作，请查阅[目录](https://github.com/hust-open-atom-club/linux-insides-zh/blob/master/SUMMARY.md)。
+
+**问题/建议**: 如有相关问题或建议，请提交 issue。一方面，对于英文原文问题，请在上游仓库 - [linux-insides](https://github.com/0xAX/linux-insides) 中提交 issue；另一方面，对于中文翻译问题，请在下游仓库 - [linux-insides-zh](https://github.com/hust-open-atom-club/linux-insides-zh) 中提交 issue。
+
+## 前置要求
+
+- 熟悉[汇编语言](https://zh.wikipedia.org/wiki/%E6%B1%87%E7%BC%96%E8%AF%AD%E8%A8%80)
+- 熟练掌握 [C 语言](https://zh.wikipedia.org/wiki/C%E8%AF%AD%E8%A8%80)
+- 此外，[Intel 软件开发者手册](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)中有大量关于 x86_64 处理器的参考资料
+
+## 贡献
+
+如有相关问题或建议，请不吝指教，提交 issues 或者 PRs。对于 `linux-insides-zh` 翻译项目，请通过以下方法进行贡献：
+
+- 将英文原文翻译为中文（目前只提供简体中文的译文）；
+- 同步尚未翻译的英文原文至本项目；
+- 根据上游英文的更新，检查并更新已有的中文译文；
+- 校对已翻译的中文译文，包括修正错别字、润色等；
+
+目前本项目的**翻译进度**与**翻译认领规则**，请查看 [TRANSLATION_STATUS.md](TRANSLATION_STATUS.md)。
+
+在开始翻译之前，请阅读 [CONTRIBUTING.md](CONTRIBUTING.md) 与 [TRANSLATION_NOTES.md](TRANSLATION_NOTES.md)。关于翻译约定的任何问题或建议，同样请提交 issue 讨论。
 
 ## 使用 mdBook 构建
 
@@ -28,40 +49,17 @@ mdbook serve --open
 
 生成结果位于 `book/` 目录。仓库同时提供了 GitHub Actions 工作流，在 `master` 分支更新后自动构建并部署 GitHub Pages。
 
-**问题/建议**: 如有相关问题或建议，请提交 issue。一方面，对于英文原文问题，请在上游仓库 - [linux-insides](https://github.com/0xAX/linux-insides) 中提交 issue；另一方面，对于中文翻译问题，请在下游仓库 - [linux-insides-zh](https://github.com/hust-open-atom-club/linux-insides-zh) 中提交 issue。
-
-## 贡献
-
-如有相关问题或建议，请不吝指教，提交 issues 或者 PRs。对于 `linux-insides-zh` 翻译项目，请通过以下方法进行贡献：
-
-- 英文翻译，目前只提供简体中文的译文；
-- 同步未被翻译的英文原本，其实就是将上游英文同步到本项目中；
-- 更新已经翻译的中文译文，其实就是查看上游英文的更新，检查是否需要对中文译文进行更新；
-- 校对当前已经翻译过的中文译文，包括修改错别字，润色等工作；
-
-目前本项目的**翻译进度**与**翻译认领规则**，请查看 [TRANSLATION_STATUS.md](TRANSLATION_STATUS.md)。
-
-在开始翻译之前，请阅读 [CONTRIBUTING.md](CONTRIBUTING.md) 与 [TRANSLATION_NOTES.md](TRANSLATION_NOTES.md)。关于翻译约定的任何问题或建议，同样请提交 issue 讨论。
-
 ## 邮件列表
 
-我们开源俱乐部内部有一个[ Google Group 邮件列表](https://groups.google.com/g/hust-os-kernel-patches)来学习和贡献 Linux 内核源码。
+我们开源俱乐部内部有一个 [Google Group 邮件列表](https://groups.google.com/g/hust-os-kernel-patches)来学习和贡献 Linux 内核源码。
 
 **加入邮件列表** 发送任意主题/内容的邮件到 hust-os-kernel-patches+subscribe@googlegroups.com。随后，你将获得一封确认邮件，并加入邮件列表。如果你有谷歌账号，你可以通过上述网址直接加入我们邮件列表。
 
-## 中文维护者
+## 维护者与作者
 
-[@mudongliang](https://github.com/mudongliang)
-
-[@xinqiu](https://github.com/xinqiu)
-
-## 中文贡献者
-
-详见 [CONTRIBUTORS.md](CONTRIBUTORS.md)
-
-## 原文作者
-
-[@0xAX](https://twitter.com/0xAX)
+- 原文作者：[@0xAX](https://x.com/0xAX)
+- 中文维护者：[@mudongliang](https://github.com/mudongliang)、[@xinqiu](https://github.com/xinqiu)
+- 中文贡献者：详见 [CONTRIBUTORS.md](CONTRIBUTORS.md)
 
 ## 许可证
 


### PR DESCRIPTION
- Rewrite intro paragraphs to match upstream and clarify this is a translation
- Add prerequisites section (assembly, C, Intel SDM)
- Clarify and polish contribution bullet points
- Reorganize sections: move mdBook build between 贡献 and 邮件列表
- Fix link formatting in mailing list section
- Consolidate 中文维护者/中文贡献者/原文作者 into one section
- Update @0xAX link from twitter.com to x.com